### PR TITLE
Release 1.0.4 - goreleaser configuration fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          workdir: cli/
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,9 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - env:
+  -
+    main: ./cli
+    env:
       - CGO_ENABLED=0
     goos:
       - linux


### PR DESCRIPTION
## Fixed
- Specify path to `main.go` in `goreleaser.yml`. Running `goreleaser release --snapshot --rm-dist` was failing with "error=build for ecs-ami-deploy does not contain a main function". 
