### PR TITLE
Use launch templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ available or not. When `--force-replacement` is enabled the process is _not_ ide
     1. If cluster is not using latest AMI, or `force replacement` is enabled, proceed to #4
     2. Else if using latest AMI already, jump to #10
  4. Create new launch template version with new AMI
- 5. Update ASG to use new launch config
+ 5. Update launch template default version and set ASG to use the latest template version (`"$Latest"`)
  6. Detach existing instances from ASG and replace with new ones
  7. Wait for new instances to reach `InService` state with ASG
  8. Watch ECS cluster instances until all new ones are registered and available

--- a/README.md
+++ b/README.md
@@ -74,6 +74,6 @@ available or not. When `--force-replacement` is enabled the process is _not_ ide
 3. Run `ecs-ami-deploy list-clusters` to check if it's working and what clusters you have available.
 4. If you have multiple profiles configured in your `~/.aws/credentials` file, you can use the `-p` or `--profile` 
    flags to specify a different profile.
-5. The CLI defaults to region `us-east-1`, you can use the `-r` or `-region` flags to specify else
+5. The CLI defaults to region `us-east-1`, you can use the `-r` or `--region` flags to specify else
 6. The CLI has help information built in for the various subcommands and their supported flags, use `-h` or `--help` 
    flags with each subcommand for more information.

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ available or not. When `--force-replacement` is enabled the process is _not_ ide
 ## Instance Replacement Process
 
  1. Look up latest AMI based on either the given AMI filter, or the default: `amzn2-ami-ecs-hvm-*-x86_64-ebs`
- 2. Identify the ASG for the given ECS cluster to get current launch configuration and instances list
- 3. Compare latest AMI with AMI in use by launch configuration
+ 2. Identify the ASG for the given ECS cluster to get current launch template and instances list
+ 3. Compare latest AMI with AMI in use by launch template
     1. If cluster is not using latest AMI, or `force replacement` is enabled, proceed to #4
     2. Else if using latest AMI already, jump to #10
- 4. Create new launch configuration with new AMI
+ 4. Create new launch template version with new AMI
  5. Update ASG to use new launch config
  6. Detach existing instances from ASG and replace with new ones
  7. Wait for new instances to reach `InService` state with ASG
@@ -71,7 +71,7 @@ available or not. When `--force-replacement` is enabled the process is _not_ ide
 1. Grab the latest binary for your platform at https://github.com/silinternational/ecs-ami-deploy/releases
 2. The CLI makes use of AWS's SDK for Go, which can load authentication credentials from various places similar to the 
    AWS CLI itself
-3. Run `ecs-ami-deploy list-cluster` to check if it's working and what clusters you have available.
+3. Run `ecs-ami-deploy list-clusters` to check if it's working and what clusters you have available.
 4. If you have multiple profiles configured in your `~/.aws/credentials` file, you can use the `-p` or `--profile` 
    flags to specify a different profile.
 5. The CLI defaults to region `us-east-1`, you can use the `-r` or `-region` flags to specify else

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 )
 
@@ -55,7 +55,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ecs-ami-deploy.yaml)")
 	rootCmd.PersistentFlags().StringVarP(&Profile, "profile", "p", "", "AWS shared credentials profile to use")
-	rootCmd.PersistentFlags().StringVarP(&Region, "region", "r", "us-east-1", "AWS shared credentials profile to use")
+	rootCmd.PersistentFlags().StringVarP(&Region, "region", "r", "us-east-1", "AWS region")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/cli/cmd/upgrade-cluster.go
+++ b/cli/cmd/upgrade-cluster.go
@@ -66,7 +66,7 @@ func init() {
 	_ = upgradeClusterCmd.MarkPersistentFlagRequired("cluster")
 
 	upgradeClusterCmd.PersistentFlags().StringVar(&launchTemplateNamePrefix, "launch-template-name-prefix",
-		"", "launch template name prefix")
+		"", "Launch template name prefix")
 	upgradeClusterCmd.PersistentFlags().BoolVar(&forceReplace, "force-replacement",
 		false, "Force replacement if current AMI is already latest")
 	upgradeClusterCmd.PersistentFlags().StringVar(&AMIFilter, "ami-filter",

--- a/cli/cmd/upgrade-cluster.go
+++ b/cli/cmd/upgrade-cluster.go
@@ -11,12 +11,12 @@ import (
 )
 
 var (
-	cluster                string
-	forceReplace           bool
-	launchConfigNamePrefix string
-	launchConfigLimit      int
-	pollingInterval        int
-	pollingTimeout         int
+	cluster                  string
+	forceReplace             bool
+	launchTemplateNamePrefix string
+	launchTemplateLimit      int
+	pollingInterval          int
+	pollingTimeout           int
 )
 
 // latestAMICmd represents the ec2 latest-ami command
@@ -28,13 +28,13 @@ var upgradeClusterCmd = &cobra.Command{
 		initAwsCfg()
 
 		upgrader, err := ead.NewUpgrader(AwsCfg, &ead.Config{
-			Cluster:                cluster,
-			AMIFilter:              AMIFilter,
-			ForceReplacement:       forceReplace,
-			LaunchConfigNamePrefix: launchConfigNamePrefix,
-			LaunchConfigLimit:      launchConfigLimit,
-			PollingInterval:        time.Duration(pollingInterval) * time.Second,
-			PollingTimeout:         time.Duration(pollingTimeout) * time.Minute,
+			Cluster:                  cluster,
+			AMIFilter:                AMIFilter,
+			ForceReplacement:         forceReplace,
+			LaunchTemplateNamePrefix: launchTemplateNamePrefix,
+			LaunchTemplateLimit:      launchTemplateLimit,
+			PollingInterval:          time.Duration(pollingInterval) * time.Second,
+			PollingTimeout:           time.Duration(pollingTimeout) * time.Minute,
 		})
 		if err != nil {
 			fmt.Println(err)
@@ -65,10 +65,16 @@ func init() {
 	upgradeClusterCmd.PersistentFlags().StringVar(&cluster, "cluster", "", "Cluster name")
 	_ = upgradeClusterCmd.MarkPersistentFlagRequired("cluster")
 
-	upgradeClusterCmd.PersistentFlags().StringVar(&launchConfigNamePrefix, "launch-config-name-prefix", "", "Launch Configuration name prefix")
-	upgradeClusterCmd.PersistentFlags().BoolVar(&forceReplace, "force-replacement", false, "Force replacement if current AMI is already latest")
-	upgradeClusterCmd.PersistentFlags().StringVar(&AMIFilter, "ami-filter", ead.DefaultAMIFilter, "AMI search filter")
-	upgradeClusterCmd.PersistentFlags().IntVar(&launchConfigLimit, "launch-config-limit", ead.DefaultLaunchConfigLimit, "Number of previous launch configurations to keep.")
-	upgradeClusterCmd.PersistentFlags().IntVar(&pollingInterval, "polling-interval-seconds", int(ead.DefaultPollingInterval.Seconds()), "Number of seconds between status checks.")
-	upgradeClusterCmd.PersistentFlags().IntVar(&pollingTimeout, "polling-timeout-minutes", int(ead.DefaultPollingTimeout.Minutes()), "Number of minutes before a polling operation times out.")
+	upgradeClusterCmd.PersistentFlags().StringVar(&launchTemplateNamePrefix, "launch-template-name-prefix",
+		"", "launch template name prefix")
+	upgradeClusterCmd.PersistentFlags().BoolVar(&forceReplace, "force-replacement",
+		false, "Force replacement if current AMI is already latest")
+	upgradeClusterCmd.PersistentFlags().StringVar(&AMIFilter, "ami-filter",
+		ead.DefaultAMIFilter, "AMI search filter")
+	upgradeClusterCmd.PersistentFlags().IntVar(&launchTemplateLimit, "launch-template-limit",
+		ead.DefaultLaunchTemplateLimit, "Number of previous launch template versions to keep.")
+	upgradeClusterCmd.PersistentFlags().IntVar(&pollingInterval, "polling-interval-seconds",
+		int(ead.DefaultPollingInterval.Seconds()), "Number of seconds between status checks.")
+	upgradeClusterCmd.PersistentFlags().IntVar(&pollingTimeout, "polling-timeout-minutes",
+		int(ead.DefaultPollingTimeout.Minutes()), "Number of minutes before a polling operation times out.")
 }

--- a/domain.go
+++ b/domain.go
@@ -9,15 +9,15 @@ import (
 )
 
 const (
-	DefaultAMIFilter          = "amzn2-ami-ecs-hvm-*-x86_64-ebs"
-	DefaultPollingTimeout     = 15 * time.Minute
-	DefaultPollingInterval    = 5 * time.Second
-	DefaultLaunchConfigLimit  = 5
-	DefaultTimestampLayout    = "20060102T150405"
-	MinimumIntervalsForStable = 6
-	TagNameASG                = "ecs-ami-deploy-asg"
-	TagNameTerminate          = "ecs-ami-deploy-terminate"
-	Version                   = "0.0.0"
+	DefaultAMIFilter           = "amzn2-ami-ecs-hvm-*-x86_64-ebs"
+	DefaultPollingTimeout      = 15 * time.Minute
+	DefaultPollingInterval     = 5 * time.Second
+	DefaultLaunchTemplateLimit = 5
+	DefaultTimestampLayout     = "20060102T150405"
+	MinimumIntervalsForStable  = 6
+	TagNameASG                 = "ecs-ami-deploy-asg"
+	TagNameTerminate           = "ecs-ami-deploy-terminate"
+	Version                    = "0.0.0"
 )
 
 type ClusterMeta struct {
@@ -26,25 +26,25 @@ type ClusterMeta struct {
 }
 
 type Config struct {
-	AMIFilter              string
-	Cluster                string
-	ForceReplacement       bool
-	LaunchConfigLimit      int
-	LaunchConfigNamePrefix string
-	Logger                 *log.Logger
-	PollingInterval        time.Duration
-	PollingTimeout         time.Duration
-	TimestampLayout        string
+	AMIFilter                string
+	Cluster                  string
+	ForceReplacement         bool
+	LaunchTemplateLimit      int
+	LaunchTemplateNamePrefix string
+	Logger                   *log.Logger
+	PollingInterval          time.Duration
+	PollingTimeout           time.Duration
+	TimestampLayout          string
 }
 
 var DefaultConfig = Config{
-	AMIFilter:              DefaultAMIFilter,
-	Cluster:                "",
-	ForceReplacement:       false,
-	LaunchConfigLimit:      DefaultLaunchConfigLimit,
-	LaunchConfigNamePrefix: "",
-	Logger:                 nil,
-	PollingInterval:        DefaultPollingInterval,
-	PollingTimeout:         DefaultPollingTimeout,
-	TimestampLayout:        DefaultTimestampLayout,
+	AMIFilter:                DefaultAMIFilter,
+	Cluster:                  "",
+	ForceReplacement:         false,
+	LaunchTemplateLimit:      DefaultLaunchTemplateLimit,
+	LaunchTemplateNamePrefix: "",
+	Logger:                   nil,
+	PollingInterval:          DefaultPollingInterval,
+	PollingTimeout:           DefaultPollingTimeout,
+	TimestampLayout:          DefaultTimestampLayout,
 }

--- a/upgrader.go
+++ b/upgrader.go
@@ -172,11 +172,6 @@ func (u *Upgrader) ListClusters() ([]ClusterMeta, error) {
 				continue
 			}
 
-			if *c.ClusterName != "appsdev-dev" {
-				fmt.Printf("skipping cluster %s\n\n", *c.ClusterName)
-				continue
-			}
-
 			_, ltd, err := u.getLaunchTemplateForASG(asg)
 			if err != nil {
 				fmt.Printf("Error getting launch template for cluster %s\n%s\n\n", *c.ClusterName, err)

--- a/upgrader.go
+++ b/upgrader.go
@@ -1020,8 +1020,10 @@ func (u *Upgrader) cleanupOldLaunchTemplates() error {
 	reverseSortLaunchTemplateVersions(versions)
 
 	for i := u.launchTemplateLimit; i < len(versions); i++ {
-		if err := u.deleteLaunchTemplateVersion(*versions[i].LaunchTemplateName, fmt.Sprintf("%d", *versions[i].VersionNumber)); err != nil {
-			return fmt.Errorf("error deleting launch template %s version %d: %s", *versions[i].LaunchTemplateName, *versions[i].VersionNumber, err)
+		versionString := fmt.Sprintf("%d", *versions[i].VersionNumber)
+		if err := u.deleteLaunchTemplateVersion(*versions[i].LaunchTemplateName, versionString); err != nil {
+			return fmt.Errorf("error deleting launch template %s version %d: %s",
+				*versions[i].LaunchTemplateName, *versions[i].VersionNumber, err)
 		}
 	}
 

--- a/upgrader.go
+++ b/upgrader.go
@@ -491,6 +491,10 @@ func (u *Upgrader) newLaunchTemplateVersionWithNewImage(lt *ec2types.LaunchTempl
 
 	newLtd.ImageId = image.ImageId
 
+	// KernelId and RamdiskId must be updated anytime a the ImageId is updated
+	newLtd.KernelId = image.KernelId
+	newLtd.RamDiskId = image.RamdiskId
+
 	// need to nil out snapshot ids of block devices so they don't reference old AMI
 	for _, b := range newLtd.BlockDeviceMappings {
 		b.Ebs.SnapshotId = nil

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	asgTypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
@@ -115,41 +113,41 @@ func Test_isNewerImage(t *testing.T) {
 //	}
 //}
 
-func TestSortLC(t *testing.T) {
+func TestSortLT(t *testing.T) {
 	now := time.Now()
 	oneDay := 60 * 24 * time.Minute
-	lcs := []asgTypes.LaunchConfiguration{
+	ltvs := []ec2types.LaunchTemplateVersion{
 		{
-			CreatedTime: aws.Time(now.Add(-oneDay)),
+			CreateTime: aws.Time(now.Add(-oneDay)),
 		},
 		{
-			CreatedTime: aws.Time(now.Add(-10 * oneDay)),
+			CreateTime: aws.Time(now.Add(-10 * oneDay)),
 		},
 		{
-			CreatedTime: aws.Time(now.Add(-20 * oneDay)),
+			CreateTime: aws.Time(now.Add(-20 * oneDay)),
 		},
 		{
-			CreatedTime: aws.Time(now.Add(-50 * oneDay)),
+			CreateTime: aws.Time(now.Add(-50 * oneDay)),
 		},
 		{
-			CreatedTime: aws.Time(now.Add(-5 * oneDay)),
+			CreateTime: aws.Time(now.Add(-5 * oneDay)),
 		},
 	}
 
-	reverseSortLaunchConfigurationsByCreatedTime(lcs)
+	reverseSortLaunchTemplateVersions(ltvs)
 
-	for i := range lcs {
+	for i := range ltvs {
 		// make sure not to test value out of range
-		if i+1 >= len(lcs) {
+		if i+1 >= len(ltvs) {
 			continue
 		}
-		if lcs[i].CreatedTime.Before(*lcs[i+1].CreatedTime) {
+		if ltvs[i].CreateTime.Before(*ltvs[i+1].CreateTime) {
 			t.Errorf("time is not sorted as expected. index %v is %v, index %v+1 is %v",
-				i, lcs[i].CreatedTime.Unix(), i, lcs[i+1].CreatedTime.Unix())
+				i, ltvs[i].CreateTime.Unix(), i, ltvs[i+1].CreateTime.Unix())
 		}
 	}
 
-	//for _, i := range lcs {
+	//for _, i := range ltvs {
 	//	log.Printf("%v - %s", i.CreatedTime.Unix(), i.CreatedTime.Format(time.RFC3339))
 	//}
 }

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -146,8 +146,4 @@ func TestSortLT(t *testing.T) {
 				i, ltvs[i].CreateTime.Unix(), i, ltvs[i+1].CreateTime.Unix())
 		}
 	}
-
-	//for _, i := range ltvs {
-	//	log.Printf("%v - %s", i.CreatedTime.Unix(), i.CreatedTime.Format(time.RFC3339))
-	//}
 }


### PR DESCRIPTION
### Changed (breaking)
- Use Launch Templates instead of Launch Configuration
- In `list-clusters`, continue to process other clusters if a cluster doesn't have any launch templates.