### PR TITLE
Fix name_template to use "ecs-ami-deploy"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ gomod:
 archives:
   -
     name_template: >-
-      idp-cli_
+      ecs-ami-deploy_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{ end }}


### PR DESCRIPTION
### Fixed
- Fix name_template to use "ecs-ami-deploy"