### PR TITLE
upgrade GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run GoReleaser in snapshot mode
-        uses: gorelease/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@v7
         if: github.event.pull_request
         with:
           version: ~> v1
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser on a release tag
-        uses: gorelease/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@v7
         if: startsWith(github.ref, 'refs/tags/')
         with:
           version: ~> v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -21,12 +21,12 @@ jobs:
         run: git fetch --force --tags
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser in snapshot mode
-        uses: goreleaser/goreleaser-action@v5
+        uses: gorelease/goreleaser-action@v7
         if: github.event.pull_request
         with:
           version: ~> v1
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser on a release tag
-        uses: goreleaser/goreleaser-action@v5
+        uses: gorelease/goreleaser-action@v7
         if: startsWith(github.ref, 'refs/tags/')
         with:
           version: ~> v1


### PR DESCRIPTION
[ITSE-2562 Upgrade GitHub Action steps that are using Node 20](https://support.gtis.sil.org/issue/ITSE-2562)

---

### Changed
- Update actions version references to latest available to include support for Node 24.